### PR TITLE
change mojangAPI to be async from main thread

### DIFF
--- a/src/main/java/mnfu/clantag/MojangCache.java
+++ b/src/main/java/mnfu/clantag/MojangCache.java
@@ -7,7 +7,7 @@ import java.util.concurrent.ConcurrentHashMap;
 
 public class MojangCache {
 
-    private static final long NAME_TTL = 24 * 60 * 60 * 1000L; // 24 hours, b/c if stale, no biggie. might display old name, and this is used more frequently.
+    private static final long NAME_TTL = 7 * 24 * 60 * 60 * 1000L; // 7 days, b/c if stale, no biggie. might display old name, and this is used more frequently.
     private static final long UUID_TTL = 15 * 60 * 1000L; // 15 minutes, b/c if stale, could be bad. inviting the wrong account to a clan for example.
 
     private final ConcurrentHashMap<UUID, CacheEntry<String>> uuidToName = new ConcurrentHashMap<>();

--- a/src/main/java/mnfu/clantag/commands/CommandUtils.java
+++ b/src/main/java/mnfu/clantag/commands/CommandUtils.java
@@ -7,6 +7,7 @@ import net.minecraft.server.network.ServerPlayerEntity;
 
 import java.util.Optional;
 import java.util.UUID;
+import java.util.concurrent.CompletableFuture;
 
 public final class CommandUtils {
 
@@ -17,13 +18,13 @@ public final class CommandUtils {
      *
      * @return an {@link Optional} containing the player's name if found, otherwise {@link Optional#empty()}
      */
-    public static Optional<String> getPlayerName(CommandContext<ServerCommandSource> context, UUID uuid) {
+    public static CompletableFuture<Optional<String>> getPlayerName(CommandContext<ServerCommandSource> context, UUID uuid) {
         ServerPlayerEntity player = context.getSource().getServer()
                 .getPlayerManager()
                 .getPlayer(uuid);
 
         if (player != null) {
-            return Optional.of(player.getName().getString());
+            return CompletableFuture.completedFuture(Optional.of(player.getName().getString()));
         }
         return MojangApi.getUsername(uuid);
     }
@@ -33,13 +34,13 @@ public final class CommandUtils {
      *
      * @return an {@link Optional} containing the UUID if found, otherwise {@link Optional#empty()}
      */
-    public static Optional<UUID> getUuid(CommandContext<ServerCommandSource> context, String playerName) {
+    public static CompletableFuture<Optional<UUID>> getUuid(CommandContext<ServerCommandSource> context, String playerName) {
         ServerPlayerEntity player = context.getSource().getServer()
                 .getPlayerManager()
                 .getPlayer(playerName);
 
         if (player != null) {
-            return Optional.of(player.getUuid());
+            return CompletableFuture.completedFuture(Optional.of(player.getUuid()));
         }
         return MojangApi.getUuid(playerName);
     }


### PR DESCRIPTION
mostly just moves over to using completable futures for this area of the code. adjusted current users of this where needed. 

this does make code more annoying to write in places when dealing with these lookups, but this means the api calls will not block the main thread anymore (really bad)

this also bumps the uuid -> username cache to 7d from 24h, since there is unfortunately no batched lookup option for this, like how there is for username -> uuid. Trying to prevent as many calls to mojang as possible.
