### PR TITLE
canonicalize clanNames, and allow special characters now.

### DIFF
--- a/src/main/java/mnfu/clantag/ClanTag.java
+++ b/src/main/java/mnfu/clantag/ClanTag.java
@@ -1,5 +1,6 @@
 package mnfu.clantag;
 
+import com.ibm.icu.lang.UCharacter;
 import eu.pb4.placeholders.api.PlaceholderResult;
 import mnfu.clantag.commands.*;
 import net.fabricmc.api.ModInitializer;
@@ -15,6 +16,7 @@ import org.slf4j.LoggerFactory;
 import eu.pb4.placeholders.api.Placeholders;
 
 import java.io.File;
+import java.text.Normalizer;
 
 import static mnfu.clantag.ClanUuidCacheBuilder.getInstance;
 import static mnfu.clantag.ClanUuidCacheBuilder.init;
@@ -118,5 +120,12 @@ public class ClanTag implements ModInitializer {
             }
             clanManager.save();
         });
+    }
+
+    public static void main(String[] args) {
+        String input = "ËxÄmPlE";
+
+        String normalized = Normalizer.normalize(input, Normalizer.Form.NFKC);
+        System.out.println(UCharacter.foldCase(normalized, true));
     }
 }

--- a/src/main/java/mnfu/clantag/commands/AdminCommand.java
+++ b/src/main/java/mnfu/clantag/commands/AdminCommand.java
@@ -36,7 +36,7 @@ public class AdminCommand {
                                     }
                                     return builder.buildFuture();
                                 })
-                                .then(CommandManager.argument("clanName", StringArgumentType.word())
+                                .then(CommandManager.argument("clanName", StringArgumentType.greedyString())
                                         .suggests((context, builder) -> {
                                             for (Clan c : clanManager.getAllClans()) {
                                                 builder.suggest(c.name());
@@ -57,7 +57,7 @@ public class AdminCommand {
                                     }
                                     return builder.buildFuture();
                                 })
-                                .then(CommandManager.argument("clanName", StringArgumentType.word())
+                                .then(CommandManager.argument("clanName", StringArgumentType.greedyString())
                                         .suggests((context, builder) -> {
                                             for (Clan c : clanManager.getAllClans()) {
                                                 builder.suggest(c.name());
@@ -71,17 +71,14 @@ public class AdminCommand {
 
                 // delete <clanName> (confirm)
                 .then(CommandManager.literal("delete")
-                        .then(CommandManager.argument("clanName", StringArgumentType.word())
+                        .then(CommandManager.argument("clanName", StringArgumentType.greedyString())
                                 .suggests((context, builder) -> {
                                     for (Clan c : clanManager.getAllClans()) {
                                         builder.suggest(c.name());
                                     }
                                     return builder.buildFuture();
                                 })
-                                .then(CommandManager.literal("confirm")
-                                        .executes(context -> executeDelete(context, true))
-                                )
-                                .executes(context -> executeDelete(context, false))
+                                .executes(this::executeDelete)
                         )
                 )
 
@@ -214,20 +211,19 @@ public class AdminCommand {
         return 1;
     }
 
-    private int executeDelete(CommandContext<ServerCommandSource> context, boolean confirm) {
-        if (!confirm) {
-            context.getSource().sendMessage(Text.literal(
-                    "Are you sure you want to do this? This action cannot be undone. If so, run: /clan disband confirm"
-            ));
-            return 1;
-        }
+    private int executeDelete(CommandContext<ServerCommandSource> context) {
         String clanName = StringArgumentType.getString(context, "clanName");
         if (clanName == null) {
             context.getSource().sendError(Text.literal("Clan not found!"));
             return 0;
         }
-        clanManager.deleteClan(clanName);
-        context.getSource().sendFeedback(() -> Text.literal("Deleted " + clanName + "!"), true);
-        return 1;
+        boolean successful = clanManager.deleteClan(clanName);
+        if (successful) {
+            context.getSource().sendFeedback(() -> Text.literal("Deleted clan " + clanName + "!"), true);
+            return 1;
+        } else {
+            context.getSource().sendError(Text.literal("Clan not found!"));
+            return 0;
+        }
     }
 }

--- a/src/main/java/mnfu/clantag/commands/CreateCommand.java
+++ b/src/main/java/mnfu/clantag/commands/CreateCommand.java
@@ -26,7 +26,7 @@ public class CreateCommand {
 
     public LiteralArgumentBuilder<ServerCommandSource> build() {
         return CommandManager.literal("create")
-                .then(CommandManager.argument("clanName", StringArgumentType.word())
+                .then(CommandManager.argument("clanName", StringArgumentType.string())
                         .then(CommandManager.argument("hexColor", StringArgumentType.word())
                                 .suggests((context, builder) -> {
                                     for (String c : colorNames) {
@@ -78,7 +78,7 @@ public class CreateCommand {
         if (clanCreated) {
             executor.sendMessage(Text.literal("Clan " + clanName + " created!"), false);
         } else {
-            context.getSource().sendError(Text.literal("Clan " + clanName + " already exists!"));
+            context.getSource().sendError(Text.literal("Clan " + clanName + " already exists, or " + clanName + " isn't an allowed name!"));
         }
 
         return 1;

--- a/src/main/java/mnfu/clantag/commands/DisbandCommand.java
+++ b/src/main/java/mnfu/clantag/commands/DisbandCommand.java
@@ -51,16 +51,23 @@ public class DisbandCommand {
 
         if (!confirm) {
             context.getSource().sendMessage(Text.literal(
-                    "Are you sure you want to do this? This action cannot be undone. If so, run: /clan disband confirm"
+                    "Are you sure you want to do this? If so, run: /clan disband confirm"
             ));
             return 1;
         }
 
         // now we know they're the leader of their clan, and they've confirmed.
-        clanManager.deleteClan(clan.name());
-        context.getSource().sendMessage(Text.literal(
-                "Clan " + clan.name() + " has been disbanded."
-        ));
+        boolean success = clanManager.deleteClan(clan.name());
+        if (success) {
+            context.getSource().sendMessage(Text.literal(
+                    "Clan " + clan.name() + " has been disbanded."
+            ));
+        } else {
+            context.getSource().sendMessage(Text.literal(
+                    "Clan " + clan.name() + " does not exist."
+            ));
+        }
+
         return 1;
     }
 }

--- a/src/main/java/mnfu/clantag/commands/InfoCommand.java
+++ b/src/main/java/mnfu/clantag/commands/InfoCommand.java
@@ -32,7 +32,7 @@ public class InfoCommand {
     public LiteralArgumentBuilder<ServerCommandSource> build() {
         return CommandManager.literal("info")
                 .executes(this::executeForSelf)
-                .then(CommandManager.argument("clanName", StringArgumentType.word())
+                .then(CommandManager.argument("clanName", StringArgumentType.greedyString())
                         .suggests((commandContext, suggestionsBuilder) -> {
                             Collection<Clan> clans = clanManager.getAllClans();
                             for (Clan c : clans) {

--- a/src/main/java/mnfu/clantag/commands/InviteCommand.java
+++ b/src/main/java/mnfu/clantag/commands/InviteCommand.java
@@ -36,7 +36,7 @@ public class InviteCommand {
 
     public LiteralArgumentBuilder<ServerCommandSource> buildAccept() {
         return CommandManager.literal("accept")
-                .then(CommandManager.argument("clanName", StringArgumentType.word())
+                .then(CommandManager.argument("clanName", StringArgumentType.greedyString())
                         .suggests((context, suggestionsBuilder) -> {
                             ServerPlayerEntity player = context.getSource().getPlayer();
                             if (player != null) {
@@ -52,7 +52,7 @@ public class InviteCommand {
 
     public LiteralArgumentBuilder<ServerCommandSource> buildDecline() {
         return CommandManager.literal("decline")
-                .then(CommandManager.argument("clanName", StringArgumentType.word())
+                .then(CommandManager.argument("clanName", StringArgumentType.greedyString())
                         .suggests((context, suggestionsBuilder) -> {
                             ServerPlayerEntity player = context.getSource().getPlayer();
                             if (player != null) {


### PR DESCRIPTION
changes the simple displayName map to use canonicalName instead.

This makes it so names like "ËxÄmPlE" are now supported, and in most commands you can search for them with similar things by nature of canonicalization. 

i.e., running /clan info EXAMPLE would pull up the clan ËxÄmPlE.

This same logic helps prevent the creation of clans with too similar of a name appearance wise